### PR TITLE
Ignore InsecureRequestWarning more consistently

### DIFF
--- a/check_purefa_alert.py
+++ b/check_purefa_alert.py
@@ -30,7 +30,15 @@ import logging
 import logging.handlers
 import nagiosplugin
 import purestorage
-import urllib3
+
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFAalert(nagiosplugin.Resource):
@@ -57,7 +65,6 @@ class PureFAalert(nagiosplugin.Resource):
 
     def get_alerts(self):
         """Gets active alerts from FlashArray."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fainfo = {}
         try:
             fa = purestorage.FlashArray(self.endpoint, api_token=self.apitoken)

--- a/check_purefa_hw.py
+++ b/check_purefa_hw.py
@@ -36,7 +36,15 @@ import logging
 import logging.handlers
 import nagiosplugin
 import purestorage
-import urllib3
+
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFAhw(nagiosplugin.Resource):
@@ -63,7 +71,6 @@ class PureFAhw(nagiosplugin.Resource):
 
     def get_status(self):
         """Gets hardware element status from flasharray."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fainfo={}
         try:
             fa = purestorage.FlashArray(self.endpoint, api_token=self.apitoken)

--- a/check_purefa_occpy.py
+++ b/check_purefa_occpy.py
@@ -34,7 +34,15 @@ import logging
 import logging.handlers
 import nagiosplugin
 import purestorage
-import urllib3
+
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFAoccpy(nagiosplugin.Resource):
@@ -65,7 +73,6 @@ class PureFAoccpy(nagiosplugin.Resource):
 
     def get_space(self):
         """Gets performance counters from flasharray."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fainfo = {}
         try:
             fa = purestorage.FlashArray(self.endpoint, api_token=self.apitoken)

--- a/check_purefa_perf.py
+++ b/check_purefa_perf.py
@@ -42,7 +42,15 @@ import logging
 import logging.handlers
 import nagiosplugin
 import purestorage
-import urllib3
+
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFAperf(nagiosplugin.Resource):
@@ -72,7 +80,6 @@ class PureFAperf(nagiosplugin.Resource):
 
     def get_perf(self):
         """Gets performance counters from flasharray."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fainfo = {}
         try:
             fa = purestorage.FlashArray(self.endpoint, api_token=self.apitoken)

--- a/check_purefb_alert.py
+++ b/check_purefb_alert.py
@@ -30,9 +30,16 @@ import argparse
 import logging
 import logging.handlers
 import nagiosplugin
-import urllib3
 from purity_fb import PurityFb, rest
 
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFBalert(nagiosplugin.Resource):
@@ -61,7 +68,6 @@ class PureFBalert(nagiosplugin.Resource):
 
     def get_alerts(self):
         """Gets active alerts from FlashBlade."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fbinfo = {}
         try:
             fb = PurityFb(self.endpoint)

--- a/check_purefb_hw.py
+++ b/check_purefb_hw.py
@@ -34,9 +34,16 @@ import argparse
 import logging
 import logging.handlers
 import nagiosplugin
-import urllib3
 from purity_fb import PurityFb, Hardware, rest
 
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFBhw(nagiosplugin.Resource):
@@ -63,7 +70,6 @@ class PureFBhw(nagiosplugin.Resource):
 
     def get_status(self):
         """Gets hardware component status from FlashBlade."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fbinfo={}
         try:
             fb = PurityFb(self.endpoint)

--- a/check_purefb_occpy.py
+++ b/check_purefb_occpy.py
@@ -36,9 +36,16 @@ import argparse
 import logging
 import logging.handlers
 import nagiosplugin
-import urllib3
 from purity_fb import PurityFb, rest
 
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFBoccpy(nagiosplugin.Resource):
@@ -79,7 +86,6 @@ class PureFBoccpy(nagiosplugin.Resource):
 
     def get_occupancy(self):
         """Gets occupancy values from FlasgBlade ."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fbinfo = {}
         try:
             fb = PurityFb(self.endpoint)

--- a/check_purefb_perf.py
+++ b/check_purefb_perf.py
@@ -40,9 +40,16 @@ import argparse
 import logging
 import logging.handlers
 import nagiosplugin
-import urllib3
 from purity_fb import PurityFb, ArrayPerformance, rest
 
+# Disable warnings using urllib3 embedded in requests or directly
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except:
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class PureFBperf(nagiosplugin.Resource):
@@ -76,7 +83,6 @@ class PureFBperf(nagiosplugin.Resource):
 
     def get_perf(self):
         """Gets performance counters from FlashBlade."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         fbinfo = {}
         try:
             fb = PurityFb(self.endpoint)


### PR DESCRIPTION
In newer versions of requests, urllib3 is bundled, and so we need to set it there.

Also see: https://stackoverflow.com/a/28002687

On second thought, ignoring insecure certificates and requests should probably be an option.

ref/NC/703245 - internal note for me