### PR TITLE
Update check_purefa_alert.py

### DIFF
--- a/check_purefa_alert.py
+++ b/check_purefa_alert.py
@@ -71,7 +71,7 @@ class PureFAalert(nagiosplugin.Resource):
             fainfo = fa.list_messages(open = True)
             fa.invalidate_cookie()
         except Exception as e:
-            raise nagiosplugin.CheckError(f'FA REST call returned "{e}"')
+            raise nagiosplugin.CheckError('FA REST call returned "{e}"')
         
         return(fainfo)
 


### PR DESCRIPTION
remove extra f that raises an error

`./check_purefa_alert.py X.X.X.X $api_token -vvv
File "./check_purefa_alert.py", line 74
               raise nagiosplugin.CheckError(f'FA REST call returned "{e}"')
                                                               ^
SyntaxError: invalid syntax
`